### PR TITLE
fix: clean up agent.yml and add remote-dev-bot.yaml for Gemini config

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -46,8 +46,6 @@ jobs:
     uses: gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml@main
     with:
       rdb_ref: main
-      default_model: gemini/gemini-pro
-      llm_api_key: ${{ secrets.GEMINI_API_KEY }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -1,0 +1,1 @@
+default_model: gemini-small


### PR DESCRIPTION
## What broke and why

The `with:` block in `.github/workflows/agent.yml` contained two entries
that are not valid inputs of the reusable workflow
(`gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml`):

```yaml
with:
  rdb_ref: main
  default_model: gemini/gemini-pro    # <-- not a valid input
  llm_api_key: ${{ secrets.GEMINI_API_KEY }}  # <-- not a valid input
```

GitHub Actions rejects workflows that pass unexpected inputs to a
reusable workflow, so the bot was failing before it could even start.

## What this PR does

**1. Restore agent.yml to a clean standard shim**

The only valid inputs to the reusable workflow are `rdb_ref` and
`command_prefix`. This PR removes the two invalid entries, leaving a
minimal and correct `with:` block:

```yaml
with:
  rdb_ref: main
```

The `GEMINI_API_KEY` secret is already correctly wired in the `secrets:`
block and will continue to be passed through.

**2. Add `remote-dev-bot.yaml` at the repo root**

Model selection belongs in the repo-level config file, not in the
workflow shim. The new file:

```yaml
default_model: gemini-small
```

This tells the bot to use Gemini by default. The `GEMINI_API_KEY` secret
you already have configured in this repo provides the key — no other
changes needed.

## Summary of changes

| File | Change |
|------|--------|
| `.github/workflows/agent.yml` | Remove invalid `default_model` and `llm_api_key` from `with:` block |
| `remote-dev-bot.yaml` | New file — sets `default_model: gemini-small` |

After merging, triggering the bot with `/agent-resolve` or `/agent resolve`
should work correctly and will use Gemini as the default model.